### PR TITLE
qemu: fix dependencies

### DIFF
--- a/recipes-bsp/optee-os/optee-os.bb
+++ b/recipes-bsp/optee-os/optee-os.bb
@@ -2,6 +2,8 @@ SUMMARY = "OP-TEE os"
 LICENSE = "BSD-2-Clause & BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=69663ab153298557a59c67a60a743e5b"
 
+DEPENDS = "python-pycrypto-native"
+
 SRC_URI = "git://github.com/OP-TEE/optee_os;protocol=https;branch=master"
 SRCREV = "2.0.0"
 

--- a/recipes-devtools/python/python-pycrypto/cross-compiling.patch
+++ b/recipes-devtools/python/python-pycrypto/cross-compiling.patch
@@ -1,0 +1,23 @@
+Index: pycrypto-2.6/setup.py
+===================================================================
+--- pycrypto-2.6.orig/setup.py
++++ pycrypto-2.6/setup.py
+@@ -271,7 +271,8 @@ class PCTBuildConfigure(Command):
+         if not os.path.exists("config.status"):
+             if os.system("chmod 0755 configure") != 0:
+                 raise RuntimeError("chmod error")
+-            cmd = "sh configure"    # we use "sh" here so that it'll work on mingw32 with standard python.org binaries
++            host = os.environ.get("HOST_SYS")
++            cmd = "ac_cv_func_malloc_0_nonnull=yes sh configure --host " + host   # we use "sh" here so that it'll work on mingw32 with standard python.org binaries
+             if self.verbose < 1:
+                 cmd += " -q"
+             if os.system(cmd) != 0:
+@@ -370,7 +371,7 @@ kw = {'name':"pycrypto",
+       'ext_modules': plat_ext + [
+             # _fastmath (uses GNU mp library)
+             Extension("Crypto.PublicKey._fastmath",
+-                      include_dirs=['src/','/usr/include/'],
++                      include_dirs=['src/'],
+                       libraries=['gmp'],
+                       sources=["src/_fastmath.c"]),
+ 

--- a/recipes-devtools/python/python-pycrypto_2.6.1.bb
+++ b/recipes-devtools/python/python-pycrypto_2.6.1.bb
@@ -1,0 +1,34 @@
+DESCRIPTION = "Cryptographic modules for Python."
+HOMEPAGE = "http://www.pycrypto.org/"
+SECTION = "devel/python"
+LICENSE = "PSFv2"
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=35f354d199e8cb7667b059a23578e63d"
+
+SRCNAME = "pycrypto"
+
+SRC_URI = "https://pypi.python.org/packages/source/p/${SRCNAME}/${SRCNAME}-${PV}.tar.gz \
+           file://cross-compiling.patch"
+
+SRC_URI[md5sum] = "55a61a054aa66812daf5161a0d5d7eda"
+SRC_URI[sha256sum] = "f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c"
+
+S = "${WORKDIR}/${SRCNAME}-${PV}"
+
+inherit autotools autotools-brokensep distutils
+
+DEPENDS += " gmp"
+
+export STAGING_INCDIR
+export STAGING_LIBDIR
+export BUILD_SYS
+export HOST_SYS
+
+
+# We explicitly call distutils_do_install, since we want it to run, but
+# *don't* want the autotools install to run, since this package doesn't
+# provide a "make install" target.
+do_install() {
+	distutils_do_install
+}
+
+BBCLASSEXTEND = "native"

--- a/recipes-devtools/qemu/qemu_2.5.90.bb
+++ b/recipes-devtools/qemu/qemu_2.5.90.bb
@@ -9,7 +9,7 @@ SRC_URI = "git://github.com/qemu/qemu.git;protocol=https;branch=master"
 SRCREV = "de1d099a448beb2ec39af4bd9ce4dd6452a18cb5"
 S = "${WORKDIR}/git"
 
-DEPENDS = "soc-term-native"
+DEPENDS += "soc-term-native"
 
 COMPATIBLE_HOST_class-target_mips64 = "null"
 


### PR DESCRIPTION
Extend dependencies inherited by qemu.inc to
avoid failure because of missing pixman.h.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>